### PR TITLE
Handle non-semver OS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Add basic support for new ResinOS version format to fix `resin-cli` issues.
+
 ## [4.1.0] - 2017-03-23
 
 ### Changed

--- a/build/utils.js
+++ b/build/utils.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Promise, fs, resin, semver;
+var Promise, RESINOS_VERSION_REGEX, fs, resin, semver;
 
 Promise = require('bluebird');
 
@@ -24,6 +24,8 @@ semver = require('semver');
 fs = Promise.promisifyAll(require('fs'));
 
 resin = require('resin-sdk-preconfigured');
+
+RESINOS_VERSION_REGEX = /v?\d+\.\d+\.\d+(\.rev\d+)?((\-|\+).+)?/;
 
 
 /**
@@ -90,7 +92,7 @@ exports.resolveVersion = function(deviceType, versionOrRange) {
  */
 
 exports.validateVersion = function(version) {
-  if (!semver.valid(version)) {
+  if (!RESINOS_VERSION_REGEX.test(version)) {
     throw new Error('Invalid version number');
   }
 };

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -19,6 +19,8 @@ semver = require('semver')
 fs = Promise.promisifyAll(require('fs'))
 resin = require('resin-sdk-preconfigured')
 
+RESINOS_VERSION_REGEX = /v?\d+\.\d+\.\d+(\.rev\d+)?((\-|\+).+)?/
+
 ###*
 # @summary Get file created date
 # @function
@@ -72,5 +74,5 @@ exports.resolveVersion = (deviceType, versionOrRange) ->
 # @returns {void} the most recent compatible version.
 ###
 exports.validateVersion = (version) ->
-	if not semver.valid(version)
+	if not RESINOS_VERSION_REGEX.test(version)
 		throw new Error('Invalid version number')

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.4",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
-    "resin-sdk-preconfigured": "^0.1.1",
+    "resin-sdk-preconfigured": "^0.1.2",
     "rimraf": "^2.4.1",
     "semver": "^5.3.0"
   }


### PR DESCRIPTION
This one's actually simpler, since most of the semver logic is in the previous changes to resin-sdk.